### PR TITLE
Replace classes removed in Elementor 3.6

### DIFF
--- a/includes/widgets/button-load-elementor-ise.php
+++ b/includes/widgets/button-load-elementor-ise.php
@@ -1086,8 +1086,8 @@ class ISE_ButtonLoad extends Widget_Base
                                 'label' 	=> __('Color', 'infinite-scroll-elementor-td'),
                                 'type' 		=> Controls_Manager::COLOR,
                                 'scheme' => [
-                                    'type' => \Elementor\Scheme_Color::get_type(),
-                                    'value' => \Elementor\Scheme_Color::COLOR_1,
+                                    'type' => \Elementor\Core\Schemes\Color::get_type(),
+                                    'value' => \Elementor\Core\Schemes\Color::COLOR_1,
                                 ],
                                 'selectors' => [
                                     '{{WRAPPER}} .view-more-button' => 'color: {{VALUE}};',
@@ -1101,8 +1101,8 @@ class ISE_ButtonLoad extends Widget_Base
                                 'label' 	=> __('Background Color', 'infinite-scroll-elementor-td'),
                                 'type' 		=> Controls_Manager::COLOR,
                                 'scheme' => [
-                                    'type' => \Elementor\Scheme_Color::get_type(),
-                                    'value' => \Elementor\Scheme_Color::COLOR_1,
+                                    'type' => \Elementor\Core\Schemes\Color::get_type(),
+                                    'value' => \Elementor\Core\Schemes\Color::COLOR_1,
                                 ],
                                 'selectors' => [
                                     '{{WRAPPER}} .view-more-button' => 'background-color: {{VALUE}};',
@@ -1122,8 +1122,8 @@ class ISE_ButtonLoad extends Widget_Base
                                 'label' 	=> __('Color', 'infinite-scroll-elementor-td'),
                                 'type' 		=> Controls_Manager::COLOR,
                                 'scheme' => [
-                                    'type' => \Elementor\Scheme_Color::get_type(),
-                                    'value' => \Elementor\Scheme_Color::COLOR_1,
+                                    'type' => \Elementor\Core\Schemes\Color::get_type(),
+                                    'value' => \Elementor\Core\Schemes\Color::COLOR_1,
                                 ],
                                 'selectors' => [
                                     '{{WRAPPER}} .view-more-button:hover' => 'color: {{VALUE}};',
@@ -1137,8 +1137,8 @@ class ISE_ButtonLoad extends Widget_Base
                                 'label' 	=> __('Background Color', 'infinite-scroll-elementor-td'),
                                 'type' 		=> Controls_Manager::COLOR,
                                 'scheme' => [
-                                    'type' => \Elementor\Scheme_Color::get_type(),
-                                    'value' => \Elementor\Scheme_Color::COLOR_1,
+                                    'type' => \Elementor\Core\Schemes\Color::get_type(),
+                                    'value' => \Elementor\Core\Schemes\Color::COLOR_1,
                                 ],
                                 'selectors' => [
                                     '{{WRAPPER}} .view-more-button:hover' => 'background-color: {{VALUE}};',
@@ -1262,8 +1262,8 @@ class ISE_ButtonLoad extends Widget_Base
                             'separator' => 'before',
                             'type' 		=> Controls_Manager::COLOR,
                             'scheme' => [
-                                'type' => \Elementor\Scheme_Color::get_type(),
-                                'value' => \Elementor\Scheme_Color::COLOR_1,
+                                'type' => \Elementor\Core\Schemes\Color::get_type(),
+                                'value' => \Elementor\Core\Schemes\Color::COLOR_1,
                             ],
                             'default' => '#a1a1a1',
                             'selectors' => [

--- a/includes/widgets/button-load-elementor-ise.php
+++ b/includes/widgets/button-load-elementor-ise.php
@@ -44,7 +44,7 @@ class ISE_ButtonLoad extends Widget_Base
         return [ 'button-load-elementor-css' ];
     }
     
-    protected function _register_controls()
+    protected function register_controls()
     {
         $this->register_layout_content_controls();
         $this->register_button_load_style_controls();

--- a/includes/widgets/infinite-scroll-elementor-ise.php
+++ b/includes/widgets/infinite-scroll-elementor-ise.php
@@ -989,8 +989,8 @@ class ISE_InfiniteScroll extends Widget_Base
 							'separator' => 'before',
                             'type' 		=> Controls_Manager::COLOR,
                             'scheme' => [
-                                'type' => \Elementor\Scheme_Color::get_type(),
-                                'value' => \Elementor\Scheme_Color::COLOR_1,
+                                'type' => \Elementor\Core\Schemes\Color::get_type(),
+                                'value' => \Elementor\Core\Schemes\Color::COLOR_1,
                             ],
                             'default' => '#a1a1a1',
                             'selectors' => [

--- a/includes/widgets/infinite-scroll-elementor-ise.php
+++ b/includes/widgets/infinite-scroll-elementor-ise.php
@@ -44,7 +44,7 @@ class ISE_InfiniteScroll extends Widget_Base
         return [ 'infinite-scroll-elementor-css' ];
     }
     
-    protected function _register_controls()
+    protected function register_controls()
     {
         $this->register_layout_content_controls();
         $this->register_infinite_scroll_animation_style_controls();


### PR DESCRIPTION
The latest Elementor update finally removed some deprecated classes which this plugin used - I've replaced these, and also renamed some methods which will be removed in future versions. I still use this plugin on a few sites, so it would be great to get it updated in the plugin directory (at least until Elementor's built in infinite scroll functionality supports custom posts widget skins...).