### PR TITLE
Fix typo in custom selectors JS

### DIFF
--- a/includes/widgets/infinite-scroll-elementor-ise.php
+++ b/includes/widgets/infinite-scroll-elementor-ise.php
@@ -916,8 +916,7 @@ class ISE_InfiniteScroll extends Widget_Base
 					history: false ,
 					status: '.page-load-status',
 				});
-              });
-          });
+			});
         </script>
 			<?php
             }


### PR DESCRIPTION
One more thing I noticed after updating to the latest version - the JS throws an error when using the custom selectors option because of a typo.